### PR TITLE
Add Limit for Day-Streaks to Anti-Abuse Measures

### DIFF
--- a/token/distibution/README.md
+++ b/token/distibution/README.md
@@ -53,16 +53,19 @@ This means that the user is eligible for 10.83% of the total daily token distrib
 
 ### Bonus Percentages
 
-The badges work as multiplicand for the before calculated amount. This percentage bonus will be calculated ON TOP of the base-amount and accumulate, the more one have, therefore a maximum bonus of **350%** of the base amount is possible for now.
+The badges and day streaks work as multiplicands for the before calculated amount. This percentage bonus will be calculated ON TOP of the base-amount and accumulate, the more one have, therefore a maximum bonus of **500%** of the base amount is possible for now.
 
 | Badge                                                              | Multiplier | Bonus |
 | ------------------------------------------------------------------ | ---------- | ----- |
+| [Day Streak Bonus (max)](../../welcome/day-streaks.md)             | x3.0       | 200%  |
 | [Fundamental Badge](../../welcome/badges.md#fundamental-badge)     | x3.0       | 200%  |
 | [Sponsor Badge](../../welcome/badges.md#sponsor-badge)             | x2.0       | 100%  |
 | [Early-Adopter Badge](../../welcome/badges.md#early-adopter-badge) | x1.5       | 50%   |
 | [Pioneer Badge](../../welcome/badges.md#pioneer-badge)             | x1.2       | 20%   |
 | [Teacher Badge](../../welcome/badges.md#teacher-badge)             | x1.1       | 10%   |
 | [Creator Badge](../../welcome/badges.md#creator-badge)             | x1.1       | 10%   |
+
+The Day Streak Bonus is calculated using the formula `* (Streak / 10)`, where `Streak` is the number of consecutive days a user has been active. This bonus can reach a maximum of x3.0.
 
 ### Anti-Abuse Measures
 

--- a/token/distibution/README.md
+++ b/token/distibution/README.md
@@ -14,18 +14,18 @@ Our platform operates a straightforward token distribution system that features 
 
 To be eligible for daily token distribution, members' activities are assessed using the following criteria:
 
-* Number of text, voice, and image messages sent
-* Daily active time on the platform
-* Login streak
-* Badges earned during membership
+- Number of text, voice, and image messages sent
+- Daily active time on the platform
+- Login streak
+- Badges earned during membership
 
 ### Distribution Calculation
 
 The number of tokens you receive daily is calculated as a percentage of the daily supply remaining. This calculation:
 
-* Incorporates the above activities.
-* Is subject to caps to prevent abuse. Activities exceeding these caps are appreciated but not included in the calculation.
-* Each person can receive a very small percentage of the available daily supply.
+- Incorporates the above activities.
+- Is subject to caps to prevent abuse. Activities exceeding these caps are appreciated but not included in the calculation.
+- Each person can receive a very small percentage of the available daily supply.
 
 ## Formula
 
@@ -35,13 +35,13 @@ The number of tokens you receive daily is calculated as a percentage of the dail
 
 In this formula:
 
-* `Image-Messages`, `Voice-Messages`, and `Text-Messages` are the number of each type of message the user has sent. These are weighted differently, with image messages contributing the most to the base amount and text messages the least.
-* `Online-Time` is the amount of time the user has spent online. This is divided by 120 to normalize it, meaning it reduces the value to a more manageable number. The more time a user spends online, the higher their base amount.
-* `Streak` is the number of consecutive days the user has been active. This is divided by 10 to convert it into a multiplier. The longer the user's streak of activity, the higher their base amount.
-* `Badges-Bonus` is a multiplier based on the badges the user has earned. The more badges or achievements a user has, the higher their base amount.
-* `Baseamount` is the total score calculated based on the user's activity. It's used to determine the user's share of the total token distribution.
-* `Total-Baseamounts` is the sum of the base amounts of all users. It represents the total activity of all users in the system.
-* `Distribution Percentage` is the percentage of the total token distribution that the user will receive. It's calculated by dividing the user's base amount by the total base amounts of all users. The higher a user's base amount compared to the total, the larger the percentage of tokens they will receive.
+- `Image-Messages`, `Voice-Messages`, and `Text-Messages` are the number of each type of message the user has sent. These are weighted differently, with image messages contributing the most to the base amount and text messages the least.
+- `Online-Time` is the amount of time the user has spent online. This is divided by 120 to normalize it, meaning it reduces the value to a more manageable number. The more time a user spends online, the higher their base amount.
+- `Streak` is the number of consecutive days the user has been active. This is divided by 10 to convert it into a multiplier. The longer the user's streak of activity, the higher their base amount.
+- `Badges-Bonus` is a multiplier based on the badges the user has earned. The more badges or achievements a user has, the higher their base amount.
+- `Baseamount` is the total score calculated based on the user's activity. It's used to determine the user's share of the total token distribution.
+- `Total-Baseamounts` is the sum of the base amounts of all users. It represents the total activity of all users in the system.
+- `Distribution Percentage` is the percentage of the total token distribution that the user will receive. It's calculated by dividing the user's base amount by the total base amounts of all users. The higher a user's base amount compared to the total, the larger the percentage of tokens they will receive.
 
 **Distribution Percentage:**
 
@@ -79,4 +79,4 @@ This balanced approach ensures that our token distribution remains equitable and
 
 In this section, you can find an example related to this distribution.
 
-* [Example](example.md)
+- [Example](example.md)

--- a/token/distibution/README.md
+++ b/token/distibution/README.md
@@ -76,6 +76,7 @@ This balanced approach ensures that our token distribution remains equitable and
 | Voice-Messages | 10 messages/day  |
 | Image-Messages | 5 messages/day   |
 | Online-Time    | 120 minutes/day  |
+| Day-Streaks    | 30 days          |
 
 In this section, you can find an example related to this distribution.
 

--- a/token/distibution/README.md
+++ b/token/distibution/README.md
@@ -53,7 +53,7 @@ This means that the user is eligible for 10.83% of the total daily token distrib
 
 ### Bonus Percentages
 
-The badges and day streaks work as multiplicands for the before calculated amount. This percentage bonus will be calculated ON TOP of the base-amount and accumulate, the more one have, therefore a maximum bonus of **500%** of the base amount is possible for now.
+The badges and day streaks work as multiplicands for the before calculated amount. This percentage bonus will be calculated ON TOP of the base-amount and accumulate, the more one have, therefore a maximum bonus of **x10.0** of the base amount is possible for now.
 
 | Badge                                                              | Multiplier | Bonus |
 | ------------------------------------------------------------------ | ---------- | ----- |


### PR DESCRIPTION
**Description:**

This pull request adds a new measure called "Max Day-streaks" to the existing Anti-Abuse Measures. The measure limits the maximum consecutive days a user can engage in activities that contribute to token distribution beyond the specified caps. This prevents users from consistently engaging in activities beyond the limits over extended periods, ensuring a fairer distribution of tokens within the community.

**Fixes:** #4