### PR TITLE
Describe the token that exists, not the one that was planned

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ layout:
 
 ## A New and Simple Language Exchange App
 
-We're excited to announce the launch of [LangX](https://get.langx.io), a 100% free and open sourced language exchange app, best alternative of Tandem. The app is designed to help language learners connect with native speakers of the language they're learning.
+We're excited to announce the launch of [LangX](https://get.langx.io), a free-to-use, open source language exchange app, best alternative of Tandem. The app is designed to help language learners connect with native speakers of the language they're learning.
 
 ## How It Works
 
@@ -69,8 +69,8 @@ We offer a range of features to help you get the most out of your language learn
 * **🔒 Your Data, Your Privacy** : We respect your privacy. Control what data you share and manage your privacy settings easily.
 * **⭐ Rating Evaluation** : Rate your language exchange partners and receive ratings to help improve the quality of interactions in our community. _coming-soon_
 * **🌙 Night Mode Engage** : Switch to night mode for a more comfortable reading experience in low light environments.
-* **🏅 Badge** : Earn badges for your achievements and display them on your profile.
-* **💰 Zero Cost** : Experience our comprehensive language learning features at zero cost. Absolutely no hidden charges or in-app purchases.
+* **🏅 Badge** : Earn badges for your achievements and display them on your profile. _coming-soon_
+* **💰 Free to Use. Always.** : Reply to every message you get, with no limits, and correct as many as you like. LangX Pro is an optional subscription that adds filters, unlimited translation, and the ability to start as many new conversations as you want.
 * **📖 100% Open-Sourced** : Our app is completely open-sourced. Join our developer community and contribute to our codebase.
 
 And, The Most Exciting one is that

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -11,27 +11,15 @@
 ## 💰 Token
 
 * [🪙 LangX Token](token/token.md)
-* [📊 Distribution](token/distibution.md)
-* [🔒 Staking](token/staking.md)
-* [🔁 Trading](token/trading.md)
-* [💎 Utility](token/utility.md)
-* [🎨 LangX NFT](token/langx-nft.md)
+* [📊 How Tokens Are Earned](token/distibution.md)
+* [💎 Spending Tokens](token/utility.md)
 
 ## 🎓 Learn 2 Earn
 
 * [📅 Daily Tokens](learn-2-earn/daily-tokens.md)
-* [⛓️ Connect Wallet](learn-2-earn/connect-wallet.md)
-* [🪙 Claim Your Tokens](learn-2-earn/claim-your-tokens.md)
 
 ## 📚 Library
 
 * [🥇 Badges](library/badges.md)
 * [🏆 Day Streaks](library/day-streaks.md)
 * [🤖 LangX Copilot](library/language-copilot.md)
-* [🖥️ Technology](library/technology/README.md)
-  * [🔐 Wallet](library/technology/wallet.md)
-  * [🌐 WEB 3.0](library/technology/web-3.0.md)
-  * [⛓️ Blockchain](library/technology/blockchain.md)
-  * [📜 Smart Contracts](library/technology/smart-contracts.md)
-  * [🎛️ Ethereum Virtual Machine](library/technology/ethereum-virtual-machine.md)
-  * [🔎 KYC](library/technology/kyc.md)

--- a/learn-2-earn/claim-your-tokens.md
+++ b/learn-2-earn/claim-your-tokens.md
@@ -4,6 +4,18 @@ description: Claiming daily amount of tokens to your wallet.
 
 # 🪙 Claim Your Tokens
 
+{% hint style="warning" %}
+**This design is not being built.** LangX Token is an in-app point: it is
+earned by practising and teaching in the app and spent inside the app, on a
+streak freeze and on cosmetics. It cannot be bought, sold, traded, staked or
+withdrawn, it is not on a blockchain, and there is no wallet to connect.
+
+This page describes an on-chain design from an earlier plan that was never
+implemented. It is kept so that older links still resolve, not because it is a
+roadmap. If an on-chain layer is ever revisited, it will be a new document
+written after legal review — not a continuation of this one.
+{% endhint %}
+
 To complete the process on our claim website, follow these steps: First, **Connect Your Wallet** by connecting your wallet to the website. Second, verify your eligibility by clicking the **Check Eligibility** button. If eligible, you can then proceed to click the **Claim** button. Lastly, **Sign the Transaction** using your wallet to finalize the process.
 
 To complete the process on our claim website

--- a/learn-2-earn/connect-wallet.md
+++ b/learn-2-earn/connect-wallet.md
@@ -6,6 +6,18 @@ description: >-
 
 # ⛓️ Connect Wallet
 
+{% hint style="warning" %}
+**This design is not being built.** LangX Token is an in-app point: it is
+earned by practising and teaching in the app and spent inside the app, on a
+streak freeze and on cosmetics. It cannot be bought, sold, traded, staked or
+withdrawn, it is not on a blockchain, and there is no wallet to connect.
+
+This page describes an on-chain design from an earlier plan that was never
+implemented. It is kept so that older links still resolve, not because it is a
+roadmap. If an on-chain layer is ever revisited, it will be a new document
+written after legal review — not a continuation of this one.
+{% endhint %}
+
 ## Connecting Your Wallet to Your Account
 
 Currently, the ability to connect your wallet to your account is **only available through our Web App.** This feature is _not supported on iOS or Android clients._ Connecting your wallet allows for a seamless experience, enabling you to interact with our services directly through the web interface. Follow the simple steps below to connect your wallet:

--- a/learn-2-earn/daily-tokens.md
+++ b/learn-2-earn/daily-tokens.md
@@ -1,26 +1,47 @@
 ---
 description: >-
-  Detailed guide on how daily tokens are distributed based on user activities
-  and how to check your token allocation.
+  When the daily pool is worked out, how it reaches your balance, and where to
+  see it.
 ---
 
 # 📅 Daily Tokens
 
-## Token Distribution
+Most tokens land the moment you earn them: send a message, write a correction,
+get a conversation going, and the tokens are yours immediately. The **daily
+pool** is the exception — it can only be worked out once the day is over and
+everyone's activity is known.
 
-In our system, users are allocated tokens based on their participation and in app activities. These tokens represent your contribution and can be used for various purposes within our ecosystem. For more information please take a look [Distrubition](../token/distibution.md) and an [example](../token/distibution.md#example).
+## When it lands
 
-[Token distribution ](../token/distibution.md)is calculated at the end of each day. This means all activities and contributions you've made will be accounted for, and tokens will be allocated accordingly after the day has concluded.
+The pool closes at the end of the **UTC day** and is shared out among everyone
+who was active during it. A standard clock for everyone, wherever you are,
+means the same day cannot be counted twice by moving between time zones.
 
-### How to Check Your Token Allocation
+So the pool share for today reaches your balance tomorrow. Direct awards do not
+wait.
 
-To see the number of tokens you have been allocated, simply navigate to your profile. Here's how:
+Your **streak** is the one thing that runs on your own local day, not UTC —
+a streak should follow the day you actually lived.
 
-1. Log in to your account.
-2. Click on the **Profile** menu at the top right corner of the page.
-3. Within your profile page, you'll see a section labeled **"Tokens"**.
-4. Here, you can view the total amount of tokens that have been allocated to you.
+## How much
 
-Your token allocation is calculated at the end of each day, adhering to the **UTC +0 timezone**. This ensures a standardized time for all users, regardless of where you are in the world. Any activities and contributions made throughout the day will be accounted for and tokens will be allocated accordingly after the day has concluded. Please check your token balance the following day to see your updated token allocation.
+Your share depends on how active you were relative to everyone else that day.
+The weights, the caps and a worked example are in
+[How Tokens Are Earned](../token/distibution.md).
 
-Please note, the update to your token balance reflecting the day's activities will be visible the following day. Check regularly to stay informed on your token allocation.
+## Where to see it
+
+Open your profile. It shows your balance, your all-time earned total, your
+current streak, and today's counters as they build up — messages sent,
+corrections written, new conversations, and how many different people you have
+talked to.
+
+Today's counters are live, but the pool share against them is provisional: the
+real number is only known once the day closes and everyone else's activity is
+in.
+
+## Where you stand
+
+The leaderboards come in four tabs — **weekly, monthly, yearly and all-time** —
+and rank tokens **earned**, so spending never costs you your place. If you are
+outside the top of the table, your own rank is still shown.

--- a/library/badges.md
+++ b/library/badges.md
@@ -6,6 +6,14 @@ description: >-
 
 # 🥇 Badges
 
+{% hint style="warning" %}
+**Badges are not in the current release.** They were part of an earlier version
+of LangX and are planned to return in a later one. Until they do, nothing on
+this page affects how many tokens you earn — the badge multipliers described
+below are not applied. How earning works today is in
+[How Tokens Are Earned](../token/distibution.md).
+{% endhint %}
+
 ## Fundamental Badge
 
 The **Fundamental Badge** is awarded to users who not only make significant contributions through coding but also excel in various key areas critical to our project's growth and outreach. This badge celebrates individuals who go beyond coding to:

--- a/library/day-streaks.md
+++ b/library/day-streaks.md
@@ -1,33 +1,62 @@
 ---
 description: >-
-  An explanation of the importance of maintaining day streaks in language
-  learning, how they work, and the benefits they offer.
+  How day streaks work, what keeps one alive, and how to rescue a day you
+  missed.
 cover: ../.gitbook/assets/chain.png
 coverY: 0
 ---
 
 # 🏆 Day Streaks
 
-Maintaining day-streaks is a cornerstone in the process of learning new languages. It utilizes the power of habit to ensure continuous progress and solidifies daily engagement with the language being learned.
+Maintaining a day streak is a cornerstone of learning a language. It uses the
+power of habit to turn an overwhelming task into a manageable daily investment
+of time and effort.
 
-## How It Works
+## How it works
 
-Here’s the breakdown of maintaining day-streaks effectively:
+- **Do something that counts, every day.** A day is credited when you send a
+  message or write a correction. Opening the app is not enough — a streak
+  should mean you practised, not that you visited.
+- **One increment a day.** A streak grows by +1 per day, no matter how long you
+  stayed. Consistency is the thing being measured, not session length.
+- **Your day, not a server's day.** The streak runs on your own local day, which
+  is why the timezone on your profile can only be changed once a week — an
+  unrestricted timezone field would be a streak-repair button.
 
-* **Stay Online Daily:** Users are encouraged to log into the app at least once a day, fostering a routine.
-* **Increment Restrictions:** Day-streaks grow by only one increment (+1) each day, underscoring the value of consistency over sporadic long sessions.
-* **Irreversible Losses:** Once a day-streak is broken, it cannot be recovered. This rule cements the importance of not missing a single day.
+## Rescuing a missed day
 
-This approach transforms the overwhelming task of learning a new language into manageable, daily investments of time and effort.
+A broken streak used to be gone for good. It is not any more: a
+[**streak freeze**](../token/utility.md) costs 200 tokens, and if you miss a
+day, one is spent automatically and the streak survives.
 
-## Token Calculation
+You can bank two at a time. Enough for real life, not enough to make the streak
+meaningless.
 
-Engagement and progression are also incentivized through a unique token calculation system. This system uses the length of your day-streak as a multiplier in a [formula](../token/distibution.md#formula) that determines your token earnings. Therefore, maintaining a long day-streak not only signifies consistent learning but also rewards users with more tokens, enhancing the overall learning experience with tangible rewards.
+## Milestones
 
-## Leaderboard 🏆
+Reaching a milestone pays a bonus:
 
-To inject an element of motivation and competition among learners, the app features a Global Leaderboard. This leaderboard ranks users based on the length of their day-streaks, providing a graphical comparison of dedication levels across the globe. Climbing the ranks of the Global Leaderboard or simply watching your progress can serve as a powerful motivator, pushing learners to maintain their daily engagement and extend their day-streaks further.
+| Streak   | Bonus |
+| -------- | ----- |
+| 7 days   | 50    |
+| 30 days  | 250   |
+| 100 days | 1,000 |
+| 365 days | 5,000 |
 
-To compare your progress with others, simply tap your day-streak in your profile to open the Global Leaderboard. This quick access offers a motivational glance at your worldwide ranking, encouraging you to maintain and extend your learning streak.
+Beyond the bonuses, showing up daily is also the surest way to a share of the
+[daily pool](../token/distibution.md), since the pool is worked out from what
+you actually did that day.
 
-In essence, the focus on maintaining day-streaks offers an effective method for building and sustaining the habit of language learning. Through its simple yet strict rules, it encourages daily dedication, rewards consistency, and fosters a competitive yet supportive community of language learners worldwide.
+## Leaderboards 🏆
+
+The app has **weekly, monthly, yearly and all-time** leaderboards. They rank
+tokens **earned**, and every entry shows that member's streak alongside it —
+so a long streak is visible whether or not it is the number being sorted on.
+
+Your own rank is always shown, even when you are outside the top of the table.
+
+## Coming back after a break
+
+If you had a streak in an older version of LangX, it was **frozen** rather than
+lost. You can spend tokens to bring it back when you return. See
+[LangX Token](../token/token.md).

--- a/library/language-copilot.md
+++ b/library/language-copilot.md
@@ -44,4 +44,6 @@ The LangX team is tirelessly working on introducing more features to support you
 
 Join the LangX community today to experience a new era of language learning powered by AI and shaped by a commitment to privacy and community involvement. Your journey towards mastering a new language starts here.
 
-**While we are an application of exchange, culturally the same as linguistically, we still offer the opportunity to use a well trained AI-companion, whom is available 24/7. This feature is also one of the main purposes of the** [**LangX Token.**](broken-reference)
+**While we are an application of exchange, culturally the same as linguistically, we still offer the opportunity to use a well trained AI-companion, whom is available 24/7.**
+
+Copilot is included with your account rather than paid for with tokens: everyone gets a number of uses a day, and [LangX Pro](../token/token.md) lifts the limit. [Tokens](../token/utility.md) are spent on a streak freeze and on cosmetics — they never unlock a feature.

--- a/library/technology/README.md
+++ b/library/technology/README.md
@@ -7,6 +7,18 @@ description: >-
 
 # 🖥️ Technology
 
+{% hint style="warning" %}
+**This design is not being built.** LangX Token is an in-app point: it is
+earned by practising and teaching in the app and spent inside the app, on a
+streak freeze and on cosmetics. It cannot be bought, sold, traded, staked or
+withdrawn, it is not on a blockchain, and there is no wallet to connect.
+
+This page describes an on-chain design from an earlier plan that was never
+implemented. It is kept so that older links still resolve, not because it is a
+roadmap. If an on-chain layer is ever revisited, it will be a new document
+written after legal review — not a continuation of this one.
+{% endhint %}
+
 In this section, you can find the technical details related to the token.
 
 * [Wallet](wallet.md)

--- a/library/technology/blockchain.md
+++ b/library/technology/blockchain.md
@@ -4,6 +4,18 @@ description: A beginner-friendly introduction to the concept of blockchain, its 
 
 # ⛓️ Blockchain
 
+{% hint style="warning" %}
+**This design is not being built.** LangX Token is an in-app point: it is
+earned by practising and teaching in the app and spent inside the app, on a
+streak freeze and on cosmetics. It cannot be bought, sold, traded, staked or
+withdrawn, it is not on a blockchain, and there is no wallet to connect.
+
+This page describes an on-chain design from an earlier plan that was never
+implemented. It is kept so that older links still resolve, not because it is a
+roadmap. If an on-chain layer is ever revisited, it will be a new document
+written after legal review — not a continuation of this one.
+{% endhint %}
+
 Let’s break down Blockchain
 
 1. **What Is Blockchain?**

--- a/library/technology/ethereum-virtual-machine.md
+++ b/library/technology/ethereum-virtual-machine.md
@@ -4,6 +4,18 @@ description: A comprehensive guide to understanding the Ethereum Virtual Machine
 
 # 🎛️ Ethereum Virtual Machine
 
+{% hint style="warning" %}
+**This design is not being built.** LangX Token is an in-app point: it is
+earned by practising and teaching in the app and spent inside the app, on a
+streak freeze and on cosmetics. It cannot be bought, sold, traded, staked or
+withdrawn, it is not on a blockchain, and there is no wallet to connect.
+
+This page describes an on-chain design from an earlier plan that was never
+implemented. It is kept so that older links still resolve, not because it is a
+roadmap. If an on-chain layer is ever revisited, it will be a new document
+written after legal review — not a continuation of this one.
+{% endhint %}
+
 Let’s break down the Ethereum Virtual Machine (EVM):
 
 1. **What Is the EVM?**

--- a/library/technology/kyc.md
+++ b/library/technology/kyc.md
@@ -4,6 +4,18 @@ description: An in-depth guide to understanding KYC (Know Your Customer), its im
 
 # 🔎 KYC
 
+{% hint style="warning" %}
+**This design is not being built.** LangX Token is an in-app point: it is
+earned by practising and teaching in the app and spent inside the app, on a
+streak freeze and on cosmetics. It cannot be bought, sold, traded, staked or
+withdrawn, it is not on a blockchain, and there is no wallet to connect.
+
+This page describes an on-chain design from an earlier plan that was never
+implemented. It is kept so that older links still resolve, not because it is a
+roadmap. If an on-chain layer is ever revisited, it will be a new document
+written after legal review — not a continuation of this one.
+{% endhint %}
+
 ## Understanding KYC (Know Your Customer) in Depth
 
 KYC stands for Know Your Customer, and it's a critical regulatory and compliance process adopted by banks, financial institutions, and a range of companies worldwide. This procedure is fundamental in the fight against financial crimes such as money laundering, terrorist financing, and identity theft. The essence of KYC lies in its name: it's about knowing who the customers are, ensuring they are who they claim to be, and understanding their financial dealings to prevent illicit activities.

--- a/library/technology/smart-contracts.md
+++ b/library/technology/smart-contracts.md
@@ -4,6 +4,18 @@ description: An in-depth exploration of smart contracts, their functionality, be
 
 # 📜 Smart Contracts
 
+{% hint style="warning" %}
+**This design is not being built.** LangX Token is an in-app point: it is
+earned by practising and teaching in the app and spent inside the app, on a
+streak freeze and on cosmetics. It cannot be bought, sold, traded, staked or
+withdrawn, it is not on a blockchain, and there is no wallet to connect.
+
+This page describes an on-chain design from an earlier plan that was never
+implemented. It is kept so that older links still resolve, not because it is a
+roadmap. If an on-chain layer is ever revisited, it will be a new document
+written after legal review — not a continuation of this one.
+{% endhint %}
+
 Let’s unravel the mystery of smart contracts:
 
 1. **What Is a Smart Contract?**

--- a/library/technology/wallet.md
+++ b/library/technology/wallet.md
@@ -6,6 +6,18 @@ description: >-
 
 # 🔐 Wallet
 
+{% hint style="warning" %}
+**This design is not being built.** LangX Token is an in-app point: it is
+earned by practising and teaching in the app and spent inside the app, on a
+streak freeze and on cosmetics. It cannot be bought, sold, traded, staked or
+withdrawn, it is not on a blockchain, and there is no wallet to connect.
+
+This page describes an on-chain design from an earlier plan that was never
+implemented. It is kept so that older links still resolve, not because it is a
+roadmap. If an on-chain layer is ever revisited, it will be a new document
+written after legal review — not a continuation of this one.
+{% endhint %}
+
 A wallet keeps your wealth safe and secure. The same as you have your wallet in your bag, pocket or purse, the same you have it secured online as well. Probably the digital version is even more secure IF you handle it right. For our [token](broken-reference) we recommend the [METAMASK-Wallet](https://metamask.io/).
 
 1. **What Is a Crypto Wallet?**

--- a/library/technology/web-3.0.md
+++ b/library/technology/web-3.0.md
@@ -4,6 +4,18 @@ description: A detailed guide to understanding Web 3.0, its evolution from Web 1
 
 # 🌐 WEB 3.0
 
+{% hint style="warning" %}
+**This design is not being built.** LangX Token is an in-app point: it is
+earned by practising and teaching in the app and spent inside the app, on a
+streak freeze and on cosmetics. It cannot be bought, sold, traded, staked or
+withdrawn, it is not on a blockchain, and there is no wallet to connect.
+
+This page describes an on-chain design from an earlier plan that was never
+implemented. It is kept so that older links still resolve, not because it is a
+roadmap. If an on-chain layer is ever revisited, it will be a new document
+written after legal review — not a continuation of this one.
+{% endhint %}
+
 Let’s break down **Web3**:
 
 1. **What Is Web3?**

--- a/token/README.md
+++ b/token/README.md
@@ -1,28 +1,68 @@
 ---
 description: >-
-  A comprehensive guide to understanding the LangX Token, its purpose, how it
-  works, and the benefits it offers to the users of the language-exchange
-  platform.
+  What the LangX Token is, how you earn it, what you can spend it on, and what
+  it deliberately is not.
 cover: ../.gitbook/assets/site-preview.png
 coverY: 0
 ---
 
 # 🪙 LangX Token
 
-## LangX: The Economy-Token of the Language-Exchange Platform
+## An in-app point
 
-[LangX](../) stands as the proprietary economy-token for its namesake platform—a unique, free, open-source, and community-driven arena for language exchange. This document aims to shed light on all aspects of LangX, offering a comprehensive overview for newcomers and existing users alike.
+**LangX Token is an in-app point.** You earn it by using the app and you spend
+it inside the app. That is the entire definition.
 
-_**Introduction**_ [LangX](../) is the economy-token of the even-named, free, opensource and community-driven language-exchange platform. Even though the supply is limited it is still meant as encouragement for users of the app to increase their knowledge about languages and cultures of other people, countries and groups. Depending on their activity on the app, the development and growth of the community and their consistency in learning one will earn more and more of the token. The formula for the calculation is found later on this page.
+It exists for one reason: language learning works when you keep showing up, and
+a number that goes up is a good reason to show up. Every message you send and
+every sentence you correct is what keeps [LangX](../) alive as a community —
+the token is what that adds up to.
 
-### Why?
+## What it is not
 
-We, as a community, have decided to develop an own token for multiple reasons.
+This matters more than the wording, so it is worth stating without hedging:
 
-- Users can earn tokens and seamlessly transfer them to their wallets for trading, embracing a [learn-to-earn](broken-reference) model through [Web 3.0 ](../library/technology/web-3.0.md)and [blockchain](../library/technology/blockchain.md) technologies. Many platforms offer alternative or unique ecosystem tokens, but later restrict access through paywalls or limitations, eroding trust in the crypto market. Our mission is to restore faith in cryptocurrencies by providing a transparent and unrestricted token ecosystem.
-- To enhance user engagement and broaden their knowledge base, the platform should both incentivize active participation and facilitate learning.
-- Currently, we are the only language exchange platform that utilizes an actual token system.
+- **Not transferable.** It cannot be sent to another member.
+- **Not purchasable.** There is no way to buy tokens, with money or anything else.
+- **Not withdrawable.** It does not leave the app.
+- **Not tradable, not staked, not listed.** There is no exchange, no market and
+  no marketplace, and none is planned.
+- **Not on a blockchain.** There is no chain, no contract and no wallet address.
+- **It cannot unlock LangX Pro.** Pro is a subscription; tokens buy none of it.
 
-### _What is a Token ?_
+That last one is deliberate rather than incidental. The moment tokens could buy
+a Pro feature, farming tokens would become a substitute for subscribing — and
+the subscription is what pays for the app.
 
-_**Okay, interesting, so, what is a token now basically?**_ If you want to know more about [blockchain](../library/technology/blockchain.md), tokens, [Web 3.0](../library/technology/web-3.0.md) and more just find our knowledge-base. You will find whatever you need to fully understand what you are getting in touch with here.
+## Earning and spending
+
+- [**How tokens are earned**](distibution.md) — the awards, the daily caps and
+  the shared daily pool.
+- [**Spending tokens**](utility.md) — a streak freeze, and cosmetic frames and
+  titles. That is the complete list.
+- [**Daily tokens**](../learn-2-earn/daily-tokens.md) — how the pool is worked
+  out and when it lands.
+
+## Coming back from an older version of LangX?
+
+**Your balance carries over.** Nothing on LangX was ever bought or sold — what
+looked like a purchase log was the daily payout being calculated — so every
+token in your balance was earned, and there is no reason not to honour it.
+
+Balances are **divided by 100** on the way in. Better to say that plainly than
+let you find it out afterwards. The two economies were never on the same scale:
+old balances run as high as 2.28 million, while a very active day now is about
+700 tokens. Credited one-for-one, the largest balance would sit roughly nine
+years ahead of anyone new and the all-time leaderboard would never move again.
+Divided, it starts about a month ahead — a real head start, and one someone
+else can still close.
+
+You also get a welcome-back bonus, and the streak you had is frozen rather than
+lost: you can spend tokens to bring it back.
+
+{% hint style="info" %}
+**On the earlier on-chain plan.** An older version of this litepaper described
+wallets, staking, trading and an on-chain distribution layer. None of it was
+built and none of it is planned. Those pages are still reachable so old links
+do not break, but each carries a notice; they are not a roadmap.
+{% endhint %}

--- a/token/distibution.md
+++ b/token/distibution.md
@@ -1,163 +1,116 @@
 ---
 description: >-
-  Detailed explanation of how the LangX Token distribution system works,
-  including eligibility criteria, calculation formula, and anti-abuse measures.
+  How LangX Tokens are earned — the direct awards, the daily caps that keep them
+  honest, and the shared daily pool.
 ---
 
-# 📊 Distribution
+# 📊 How Tokens Are Earned
 
-## Token Distribution
+Tokens come from two places: **direct awards**, paid the moment you do
+something, and a **daily pool** that is shared out at the end of the day among
+everyone who was active.
 
-Our platform operates a straightforward token distribution system that features both a general limit and a daily limit on the number of tokens allocated. These tokens are distributed based on a member's contribution to the community, measured through various activities.
+## Direct awards
 
-### Eligibility for Daily Tokens
+| What you did                                                      | Tokens |
+| ----------------------------------------------------------------- | ------ |
+| Send a message                                                    | 2      |
+| Write a correction on someone's sentence                          | 10     |
+| Get a conversation going — the first time you and a partner have both spoken | 15     |
 
-To be eligible for daily token distribution, members' activities are assessed using the following criteria:
+A correction is worth five messages, and that ratio is not an accident.
+Teaching someone is the behaviour the platform exists for, so it is the
+behaviour worth paying for. Corrections have no daily cap on either the free or
+the Pro tier.
 
-- Number of text, voice, and image messages sent
-- Daily active time on the platform
-- [Day Streaks](../library/day-streaks.md), consecutive days of activity
-- [Badges](../library/badges.md), that have been earned
+### Caps on message tokens
 
-### Distribution Calculation
+| Cap                                  | Limit                  |
+| ------------------------------------ | ---------------------- |
+| Messages that pay, per day           | 100 (up to 200 tokens) |
+| Messages that pay, from one partner  | 30 (up to 60 tokens)   |
 
-The number of tokens you receive daily is calculated as a percentage of the daily supply remaining. This calculation:
+The per-partner cap is what stops two accounts from farming each other, and the
+daily cap is what stops volume from beating quality. Anything past the cap
+still helps the person you are talking to; it just does not pay again.
 
-- Incorporates the above activities.
-- Is subject to caps to prevent abuse. Activities exceeding these caps are appreciated but not included in the calculation.
-- Each person can receive a very small percentage of the available daily supply.
+Both caps reset at **00:00 UTC**, the same clock the pool and the leaderboards
+use. Your **streak** is the one thing measured in your own local day.
 
-## Formula
+## The daily pool
 
-### Base Amount Calculation
+Every day, **10,000 tokens** are shared out among the members who were active
+that day, in proportion to how active they were. Nobody's share is fixed —
+yours depends on everyone else's day as well as your own, which is what keeps
+it worth watching.
 
-The `Baseamount` is calculated using the following formula:
-
-$$
-\begin{align*} \text{Baseamount} = & (Text \times 10 + Voice \times 100 + Image \times 200) \\ & \times \left(\frac{\text{Online-Time}}{120}\right) \\ & \times \left(\frac{\text{Streak}}{10}\right) \\ & \times \text{Badges-Bonus} \end{align*}
-$$
-
-> Note that if no messages are sent within the day, the value will be 0.
-
-### Distribution Percentage
-
-The `Distribution Percentage` is the proportion of the total daily token distribution that a user is eligible for. It's calculated by dividing the user's base amount by the total base amounts of all users.
-
-For example, if the total base amounts for all users is 9000 and a user's base amount is 975, the `Distribution Percentage` for that user would be `975 / 9000 = 0.1083` or 10.83%.
-
-This means that the user is eligible for 10.83% of the total daily token distribution.
-
-The distribution percentage is calculated as follows:
+Your activity score for the day:
 
 $$
-\text{Distribution Percentage} = \frac{\text{Baseamount}}{\text{Total-Baseamounts}}
+\text{Score} = 5 \times \text{Conversations} + 3 \times \text{Corrections} + 1 \times \min(\text{Messages}, 50) + 4 \times \text{Partners}
 $$
 
-### Parameters Description
+| Term            | What it counts                                                    |
+| --------------- | ----------------------------------------------------------------- |
+| `Conversations` | New conversations where both sides spoke for the first time today |
+| `Corrections`   | Corrections you wrote today                                       |
+| `Messages`      | Messages you sent today, counted up to 50                         |
+| `Partners`      | Distinct people you talked to today                               |
 
-The table below provides a description of each parameter used in the calculation of the `Baseamount` and `Distribution Percentage`.
+Talking to **four different people** is worth more than sending four times as
+many messages to one, which is the behaviour the pool is trying to buy.
 
-| Parameter                 | Description                                                                                                                                                                                                                                                                         |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Text`                    | The number of text messages the user has sent. These contribute the least to the base amount.                                                                                                                                                                                       |
-| `Voice`                   | The number of voice messages the user has sent. These contribute moderately to the base amount.                                                                                                                                                                                     |
-| `Image`                   | The number of image messages the user has sent. These contribute the most to the base amount.                                                                                                                                                                                       |
-| `Online-Time`             | The amount of time in minutes the user has spent online. This is divided by 120 to normalize it. The more time a user spends online, the higher their base amount.                                                                                                                  |
-| `Streak`                  | The number of consecutive days the user has been active. This is divided by 10 to convert it into a multiplier. The longer the user's streak of activity, the higher their base amount.                                                                                             |
-| `Badges-Bonus`            | A multiplier based on the badges the user has earned. The more badges or achievements a user has, the higher their base amount.                                                                                                                                                     |
-| `Baseamount`              | The total score calculated based on the user's activity. It's used to determine the user's share of the total token distribution.                                                                                                                                                   |
-| `Total-Baseamounts`       | The sum of the base amounts of all users. It represents the total activity of all users in the system.                                                                                                                                                                              |
-| `Distribution Percentage` | The percentage of the total token distribution that the user will receive. It's calculated by dividing the user's base amount by the total base amounts of all users. The higher a user's base amount compared to the total, the larger the percentage of tokens they will receive. |
-
-### Bonus Multipliers
-
-#### Badges Bonus
-
-Badges work as multiplicands for the previously calculated amount. This percentage bonus is calculated on top of the base amount and accumulates with each badge. Therefore, a maximum bonus of **x10.0** of the base amount is possible for now. For example, if you have the Early-Adopter and Pioneer badges, the bonus would be calculated as (1 + 0.5 + 0.2) = 1.7, meaning a 70% increase on the base amount.
-
-| Badge                                                           | Bonus Multiplier | Bonus Percentage |
-| --------------------------------------------------------------- | ---------------- | ---------------- |
-| [Fundamental Badge](../welcome/badges.md#fundamental-badge)     | x3.0             | 200%             |
-| [Backer Badge](../welcome/badges.md#backer-badge)               | x2.0             | 100%             |
-| [Early-Adopter Badge](../welcome/badges.md#early-adopter-badge) | x1.5             | 50%              |
-| [Pioneer Badge](../welcome/badges.md#pioneer-badge)             | x1.2             | 20%              |
-| [Teacher Badge](../welcome/badges.md#teacher-badge)             | x1.1             | 10%              |
-| [Creator Badge](../welcome/badges.md#creator-badge)             | x1.1             | 10%              |
-
-**Calculation Method**
-
-To calculate the total bonus, sum up the bonus percentages of all the badges you possess and add 1 (representing the base amount). The result is your total multiplier. For example, if you have the **Fundamental Badge** and the **Teacher Badge**, the calculation would be:
+Your share:
 
 $$
-\text{Badges-Bonus} = 1 + 2.0 + 0.1 = 3.1
+\text{Share} = \left\lfloor 10{,}000 \times \frac{\text{Your Score}}{\text{Everyone's Score}} \right\rfloor
 $$
 
-This means you get a 210% increase on the base amount.
+capped at **5% of the pool** (500 tokens), no matter how quiet the day was.
 
-#### Day Streak Bonus
+### Worked example
 
-Day streaks also work as multiplicands for the previously calculated amount. This bonus is calculated using the formula `(Streak / 10)`, where `Streak` is the number of consecutive days a user has been active. This bonus can reach a maximum of **x3.0**.
-
-| Streak                                                                | Multiplier | Bonus |
-| --------------------------------------------------------------------- | ---------- | ----- |
-| [Day Streak Bonus](../library/day-streaks.md) [(formula)](./#formula) | x3.0       | 200%  |
-
-## Example
-
-To understand the distribution of one-time bonuses for referred friends based on daily activities, let's break down the formula with an example.
-
-### Recall Formula
-
-The [formula](distibution.md#formula) for the daily bonus distribution factors in user engagement metrics like message counts, online duration, activity streaks, and badge bonuses to compute a Baseamount. This determines a user's share of daily tokens, ensuring fair and proportional rewards. It incentivizes meaningful participation, fostering a vibrant and engaged community by basing rewards on the value contributed to the platform.
-
-### Inputs
-
-| Parameter                                    | Value         |
-| -------------------------------------------- | ------------- |
-| Text messages sent                           | 80            |
-| Audio messages sent                          | 3             |
-| Image messages sent                          | 1             |
-| Online time                                  | 60 minutes    |
-| Streak                                       | 10 days       |
-| Badges bonus (Early Adopter and Pioneer)     | 1 + 0.5 + 0.2 |
-| Daily tokens to be allocated by the contract | 10,000 tokens |
-
-### Calculation Steps
+You send 30 messages to 4 different people, write 3 corrections, and one new
+conversation gets going both ways:
 
 $$
-\begin{align*} \text{Baseamount} = & (80 \times 10 + 3 \times 100 + 1 \times 200) \\ & \times \left(\frac{\text{60}}{120}\right) \\ & \times \left(\frac{\text{10}}{10}\right) \\ & \times \text{1 + 0.5 + 0.2} \\ = & 1300 \times 0.5 \times 1 \times 1.7 \\ = & 1105 \end{align*}
+\text{Score} = 5 \times 1 + 3 \times 3 + 1 \times 30 + 4 \times 4 = 60
 $$
 
-$$
-\begin{align*} \text{Distribution Percentage} = & \frac{\text{Baseamount}}{\text{Total-Baseamounts}} \\ = & \frac{\text{1105}}{\text{50000}} \\ = & 0.0221 \end{align*}
-$$
+If everyone's scores add up to 3,000 that day, your share is
+$$\lfloor 10{,}000 \times 60 / 3{,}000 \rfloor = 200$$ tokens — on top of the
+2 × 30 + 10 × 3 + 15 = 105 tokens you were already paid directly.
 
-> Assume `Total-Baseamounts` (the sum of Base Amounts of All Users) is **50000**.
+### Two conditions
 
-Then, Distribution Percentage is equal **0.0221** or **2.21%**
+- **Accounts younger than 24 hours earn no pool share.** A pool that paid out
+  to hour-old accounts would be a throwaway-account generator.
+- **A quiet day distributes nothing** rather than dividing a fixed pot among
+  three people.
 
-This result signifies you are eligible for 2.21% of the daily token distribution.
+## Streak bonuses
 
-### Final Calculation
+Keeping a daily streak pays a bonus when you reach a milestone:
 
-`Distribution = Distribution Percentage * Daily tokens = 0.0432 * 10,000 = 432 tokens`
+| Streak   | Bonus |
+| -------- | ----- |
+| 7 days   | 50    |
+| 30 days  | 250   |
+| 100 days | 1,000 |
+| 365 days | 5,000 |
 
-$$
-\begin{align*} \text{Distribution} = & \text{Distribution Percentage} \times \text{Daily tokens} \\ = & \text{0.0221} \times \text{10000} \\ = & 221 \end{align*}
-$$
+A day counts towards the streak when you do something meaningful — send a
+message or write a correction. Opening the app does not count. See
+[Day Streaks](../library/day-streaks.md).
 
-This example leads to a total distribution of **221 tokens** due to your activity level and your all Badges and Day Streak bonuses.
+## Why these numbers are public
 
-## Anti-Abuse Measures
+Every rate, cap and weight on this page is in the app's source, in the open, in
+`packages/shared`. That is fine: none of it is enforced by being secret. Awards
+are written server-side, once, against a unique ledger entry per event — so an
+award cannot be paid twice, whatever the client says.
 
-To ensure fairness and prevent exploitation, specific caps have been implemented across all parameters. Activities that exceed these caps contribute positively to the community but do not increase the token distribution amount.
-
-This balanced approach ensures that our token distribution remains equitable and rewards meaningful contributions to our community.
-
-| Feature        | Limit            |
-| -------------- | ---------------- |
-| Text-Messages  | 100 messages/day |
-| Voice-Messages | 10 messages/day  |
-| Image-Messages | 5 messages/day   |
-| Online-Time    | 120 minutes/day  |
-| Day-Streaks    | 30 days          |
+These are also **starting values**. The right pool size and weights can only
+really be found with real activity, so expect them to be tuned. The ledger they
+are written to is append-only, which means a change can always be applied
+without rewriting anyone's history.

--- a/token/langx-nft.md
+++ b/token/langx-nft.md
@@ -6,6 +6,18 @@ description: >-
 
 # 🎨 LangX NFT
 
+{% hint style="warning" %}
+**This design is not being built.** LangX Token is an in-app point: it is
+earned by practising and teaching in the app and spent inside the app, on a
+streak freeze and on cosmetics. It cannot be bought, sold, traded, staked or
+withdrawn, it is not on a blockchain, and there is no wallet to connect.
+
+This page describes an on-chain design from an earlier plan that was never
+implemented. It is kept so that older links still resolve, not because it is a
+roadmap. If an on-chain layer is ever revisited, it will be a new document
+written after legal review — not a continuation of this one.
+{% endhint %}
+
 ## Earning Badges as NFTs
 
 ### Introduction

--- a/token/staking.md
+++ b/token/staking.md
@@ -6,6 +6,18 @@ description: >-
 
 # 🔒 Staking
 
+{% hint style="warning" %}
+**This design is not being built.** LangX Token is an in-app point: it is
+earned by practising and teaching in the app and spent inside the app, on a
+streak freeze and on cosmetics. It cannot be bought, sold, traded, staked or
+withdrawn, it is not on a blockchain, and there is no wallet to connect.
+
+This page describes an on-chain design from an earlier plan that was never
+implemented. It is kept so that older links still resolve, not because it is a
+roadmap. If an on-chain layer is ever revisited, it will be a new document
+written after legal review — not a continuation of this one.
+{% endhint %}
+
 Let’s delve into the world of staking in the crypto space. Staking is a fascinating concept that allows you to earn passive income with your digital assets. Here’s what you need to know.
 
 ## **What Is Staking?**

--- a/token/token.md
+++ b/token/token.md
@@ -1,28 +1,68 @@
 ---
 description: >-
-  A comprehensive guide to understanding the LangX Token, its purpose, how it
-  works, and the benefits it offers to the users of the language-exchange
-  platform.
+  What the LangX Token is, how you earn it, what you can spend it on, and what
+  it deliberately is not.
 cover: ../.gitbook/assets/site-preview.png
 coverY: 0
 ---
 
 # 🪙 LangX Token
 
-## LangX: The Economy-Token of the Language-Exchange Platform
+## An in-app point
 
-[LangX](../) stands as the proprietary economy-token for its namesake platform—a unique, free, open-source, and community-driven arena for language exchange. This document aims to shed light on all aspects of LangX, offering a comprehensive overview for newcomers and existing users alike.
+**LangX Token is an in-app point.** You earn it by using the app and you spend
+it inside the app. That is the entire definition.
 
-_**Introduction**_ [LangX](../) is the economy-token of the even-named, free, opensource and community-driven language-exchange platform. Even though the supply is limited it is still meant as encouragement for users of the app to increase their knowledge about languages and cultures of other people, countries and groups. Depending on their activity on the app, the development and growth of the community and their consistency in learning one will earn more and more of the token. The formula for the calculation is found later on this page.
+It exists for one reason: language learning works when you keep showing up, and
+a number that goes up is a good reason to show up. Every message you send and
+every sentence you correct is what keeps [LangX](../) alive as a community —
+the token is what that adds up to.
 
-### Why?
+## What it is not
 
-We, as a community, have decided to develop an own token for multiple reasons.
+This matters more than the wording, so it is worth stating without hedging:
 
-- Users can earn tokens and seamlessly transfer them to their wallets for trading, embracing a [learn-to-earn](broken-reference) model through [Web 3.0 ](../library/technology/web-3.0.md)and [blockchain](../library/technology/blockchain.md) technologies. Many platforms offer alternative or unique ecosystem tokens, but later restrict access through paywalls or limitations, eroding trust in the crypto market. Our mission is to restore faith in cryptocurrencies by providing a transparent and unrestricted token ecosystem.
-- To enhance user engagement and broaden their knowledge base, the platform should both incentivize active participation and facilitate learning.
-- Currently, we are the only language exchange platform that utilizes an actual token system.
+- **Not transferable.** It cannot be sent to another member.
+- **Not purchasable.** There is no way to buy tokens, with money or anything else.
+- **Not withdrawable.** It does not leave the app.
+- **Not tradable, not staked, not listed.** There is no exchange, no market and
+  no marketplace, and none is planned.
+- **Not on a blockchain.** There is no chain, no contract and no wallet address.
+- **It cannot unlock LangX Pro.** Pro is a subscription; tokens buy none of it.
 
-### _What is a Token ?_
+That last one is deliberate rather than incidental. The moment tokens could buy
+a Pro feature, farming tokens would become a substitute for subscribing — and
+the subscription is what pays for the app.
 
-_**Okay, interesting, so, what is a token now basically?**_ If you want to know more about [blockchain](../library/technology/blockchain.md), tokens, [Web 3.0](../library/technology/web-3.0.md) and more just find our knowledge-base. You will find whatever you need to fully understand what you are getting in touch with here.
+## Earning and spending
+
+- [**How tokens are earned**](distibution.md) — the awards, the daily caps and
+  the shared daily pool.
+- [**Spending tokens**](utility.md) — a streak freeze, and cosmetic frames and
+  titles. That is the complete list.
+- [**Daily tokens**](../learn-2-earn/daily-tokens.md) — how the pool is worked
+  out and when it lands.
+
+## Coming back from an older version of LangX?
+
+**Your balance carries over.** Nothing on LangX was ever bought or sold — what
+looked like a purchase log was the daily payout being calculated — so every
+token in your balance was earned, and there is no reason not to honour it.
+
+Balances are **divided by 100** on the way in. Better to say that plainly than
+let you find it out afterwards. The two economies were never on the same scale:
+old balances run as high as 2.28 million, while a very active day now is about
+700 tokens. Credited one-for-one, the largest balance would sit roughly nine
+years ahead of anyone new and the all-time leaderboard would never move again.
+Divided, it starts about a month ahead — a real head start, and one someone
+else can still close.
+
+You also get a welcome-back bonus, and the streak you had is frozen rather than
+lost: you can spend tokens to bring it back.
+
+{% hint style="info" %}
+**On the earlier on-chain plan.** An older version of this litepaper described
+wallets, staking, trading and an on-chain distribution layer. None of it was
+built and none of it is planned. Those pages are still reachable so old links
+do not break, but each carries a notice; they are not a roadmap.
+{% endhint %}

--- a/token/trading.md
+++ b/token/trading.md
@@ -7,6 +7,18 @@ description: >-
 
 # 🔁 Trading
 
+{% hint style="warning" %}
+**This design is not being built.** LangX Token is an in-app point: it is
+earned by practising and teaching in the app and spent inside the app, on a
+streak freeze and on cosmetics. It cannot be bought, sold, traded, staked or
+withdrawn, it is not on a blockchain, and there is no wallet to connect.
+
+This page describes an on-chain design from an earlier plan that was never
+implemented. It is kept so that older links still resolve, not because it is a
+roadmap. If an on-chain layer is ever revisited, it will be a new document
+written after legal review — not a continuation of this one.
+{% endhint %}
+
 ## Trading the LangX Token
 
 Welcome to the essential guide on trading the LangX Token, a novel asset in the ever-evolving cryptocurrency space. Trading in digital currencies like the LangX Token entails distinct risks and demands an understanding of the blockchain technology it's built on. Below, we provide key insights to help you navigate the trading landscape of this unique token. Remember, thorough research and a comprehensive grasp of the market are pivotal to trading success.

--- a/token/utility.md
+++ b/token/utility.md
@@ -1,28 +1,54 @@
 ---
 description: >-
-  An exploration of the various uses of LangX Tokens within the platform, from
-  enhancing the learning experience to serving as a reward system and
-  marketplace currency.
+  The complete list of what LangX Tokens can be spent on — a streak freeze, and
+  cosmetic frames and titles.
 ---
 
-# 💎 Utility
+# 💎 Spending Tokens
 
-## Utility of Tokens
+There are exactly two things to spend tokens on. The list is short on purpose,
+and it is worth explaining why before going through it.
 
-This dual functionality not only enhances the immediate learning experience but also builds a supportive and appreciative community of learners. As LangX tokens become more integrated into different aspects of the platform, from exclusive market transactions to potential savings mechanisms, their value extends beyond mere currency. They represent a commitment to ongoing education, mutual respect among users, and an open-minded approach to the evolving digital economy. The future implementation of a marketplace further solidifies their position as a vital component of the LangX ecosystem, offering users unique ways to personalize their learning experience and engage with the community. Through these diverse applications, LangX tokens are not just facilitating transactions; they are enriching the educational journey, fostering a vibrant community, and bridging the gap between learning and real-world application.
+## Streak freeze — 200 tokens
 
-### Overview
+A streak freeze rescues a day you missed, so one bad day does not undo months
+of practice. Buy one in advance; if you miss a day, it is spent automatically
+and your streak survives.
 
-1. The primary use of LangX tokens is to enhance one's learning experience and knowledge progression with our AI support tool, [**Copilot**](../library/language-copilot.md). Users can interact not only with real people but also with an AI that responds in real-time, providing a continuous learning opportunity, regardless of the availability of other users.
-2. LangX tokens can also be used as a reward system, allowing users to send tokens to each other as a form of appreciation for help or services provided during practice sessions.
-3. In the future, we plan to implement a marketplace for platform-exclusive emoticons and expressions, where LangX tokens will be the only accepted currency.
-4. Similar to traditional saving accounts, LangX Tokens can be [staked](staking.md) in the world of cryptocurrency.
-5. Lastly, users can withdraw their LangX tokens to their personal [wallet](../library/technology/wallet.md) and either purchase more tokens or sell them on the market while [trading](trading.md).
+You can bank **two at a time**. That is enough to cover real life — a flight, a
+hospital visit, a week that got away from you — and not enough to make the
+streak meaningless. A stockpile of freezes would turn a streak into a number
+you bought rather than a habit you kept.
 
-### Summary
+## Frames and titles
 
-- **Learning Enhancement:** LangX tokens primarily serve to enhance the learning experience through AI support, allowing for real-time interaction.
-- **Reward System:** Tokens can be used as a reward, enabling users to show appreciation for assistance received during practice sessions.
-- **Marketplace Currency:** Future plans include the launch of a marketplace for exclusive emoticons and expressions, with LangX tokens as the sole currency.
-- **Savings:** LangX Tokens can also function similarly to traditional savings in the cryptocurrency realm.
-- **Withdrawals & Transactions:** Users have the option to withdraw their tokens to personal wallets, facilitating the buying or selling of tokens on the market.
+Cosmetic frames around your avatar, and titles shown next to your name. They
+change how your profile looks and nothing else.
+
+| Item           | Tokens |
+| -------------- | ------ |
+| Bronze frame   | 500    |
+| Silver frame   | 1,500  |
+| Gold frame     | 5,000  |
+| Learner title  | 1,000  |
+| Tutor title    | 3,000  |
+| Polyglot title | 10,000 |
+
+## Why the list ends there
+
+Tokens **cannot** buy a LangX Pro feature — not filters, not unlimited
+translation, not the ability to start more conversations. That is deliberate.
+The moment tokens could buy a Pro feature, farming tokens would become a
+substitute for subscribing, and the subscription is what pays for running the
+app. Keeping the sinks cosmetic is what lets the token economy be generous
+without undermining the thing that funds it.
+
+For the same reason there is no way to buy tokens, send them to another member,
+or take them out of the app. See [LangX Token](token.md).
+
+## Spending does not cost you your rank
+
+The leaderboards rank tokens **earned**, not tokens held. Buying a gold frame
+does not drop you down the table — your balance falls, your all-time total does
+not. Spending and ranking are two different numbers, so you never have to
+choose between them.


### PR DESCRIPTION
## Why

This litepaper documents wallets, staking, trading, an NFT and an on-chain distribution layer. **None of it was built and none of it is planned.** LangX v2 ships the token as an in-app point: earned by practising and teaching, spent on a streak freeze and on cosmetics, and nothing else.

Leaving the old pages up unqualified was the worst of the available options — it reads as a roadmap, and an app whose official documentation advertises staking and trading invites a store rejection under Apple's rules for crypto-adjacent apps (3.1.5(b)). v1 was free with no in-app purchases, so v2 walks into a fresh, thorough review regardless.

Source of truth for this rewrite: `docs/token-messaging-brief.md` in `langx-io/langx2`, plus `packages/shared/src/token.ts` (`TOKEN_RULES`) and `cosmetics.ts` for every number quoted here.

## What changed

**The twelve Web3 pages are kept, not deleted** — staking, trading, NFT, connect-wallet, claim-your-tokens, and the whole `library/technology/` subtree (wallet, Web 3.0, blockchain, smart contracts, EVM, KYC). Old links still resolve. Each now opens with a notice saying the design is not being built, and none of them appears in `SUMMARY.md` any more.

**The pages that stay are rewritten from the app's own configuration:**

| Page | Now says |
| --- | --- |
| `token/token.md` (and its `README.md` twin) | What the token is, an explicit "what it is not" list, and the 1:100 carry-over for returning members |
| `token/distibution.md` → *How Tokens Are Earned* | 2 / 10 / 15 awards, the 100-per-day and 30-per-partner message caps, the 10,000-token daily pool with its real weights and a worked example |
| `token/utility.md` → *Spending Tokens* | Streak freeze (200, two bankable) and the cosmetics price table, and why that list is closed |
| `learn-2-earn/daily-tokens.md` | The pool closes on the UTC day; the streak runs on the user's local day |
| `library/day-streaks.md` | A missed day can be rescued now — the old page said losses were irreversible — and a day needs a meaningful action, not a login |

**Notices rather than rewrites:** `library/badges.md` (badges are not in the current release, so the multipliers on that page do not apply) and `library/language-copilot.md` (Copilot is included with the account and gated by plan, not paid for with tokens).

**Front page:** "💰 Zero Cost — absolutely no hidden charges or in-app purchases" is no longer true once the subscription ships; replaced with the wording approved in `langx2/docs/legal/promise-change.md`. Badges marked `_coming-soon_`.

## For the reviewer

- **There is a deliberate tone shift.** The old litepaper was written in the language of a crypto project — "our mission is to restore faith in cryptocurrencies". The new text drops that register entirely. This is an editorial call as much as a factual one and is worth a read rather than a skim, particularly `token/token.md`.
- **`token/README.md` is byte-identical to `token/token.md`**, as it was before this change — GitBook uses the README as the section index.
- One number was corrected mid-review and is worth double-checking: the message caps count **messages, not tokens**. `awards.ts` compares `activity.messages` against `TOKEN_RULES.caps.messagesPerDay`, so 100 messages a day is worth up to 200 tokens. The misleading source comment is fixed separately in `langx2`.
- All internal links were checked; none are broken.
- The matching change to `token.langx.io` is already live: `langx/token-website@6d73d55`.