### PR TITLE
Put the unbuilt pages back in the tree, under a section that says so

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -23,3 +23,18 @@
 * [🥇 Badges](library/badges.md)
 * [🏆 Day Streaks](library/day-streaks.md)
 * [🤖 LangX Copilot](library/language-copilot.md)
+
+## 🗄️ Not Built
+
+* [🔒 Staking](token/staking.md)
+* [🔁 Trading](token/trading.md)
+* [🎨 LangX NFT](token/langx-nft.md)
+* [⛓️ Connect Wallet](learn-2-earn/connect-wallet.md)
+* [🪙 Claim Your Tokens](learn-2-earn/claim-your-tokens.md)
+* [🖥️ Technology](library/technology/README.md)
+  * [🔐 Wallet](library/technology/wallet.md)
+  * [🌐 WEB 3.0](library/technology/web-3.0.md)
+  * [⛓️ Blockchain](library/technology/blockchain.md)
+  * [📜 Smart Contracts](library/technology/smart-contracts.md)
+  * [🎛️ Ethereum Virtual Machine](library/technology/ethereum-virtual-machine.md)
+  * [🔎 KYC](library/technology/kyc.md)


### PR DESCRIPTION
## The problem

[#12](https://github.com/langx/docs/pull/12) added a "this design is not being built" notice to the twelve Web3 pages (staking, trading, NFT, connect-wallet, claim-your-tokens, and the whole `library/technology/` subtree) and removed them from `SUMMARY.md`, on the assumption that the pages would stay reachable and only drop out of the navigation.

That assumption was wrong. **GitBook builds its page tree from `SUMMARY.md` alone**, so removing an entry unpublishes the page. Checked against the live site after the sync completed:

| URL | Before this PR |
| --- | --- |
| `/litepaper/token/staking` | **404** |
| `/litepaper/library/technology/wallet` | **404** |
| `/litepaper/token/token` | 200, new content |
| `/litepaper/library/badges` | 200, notice visible |

So every notice written in #12 was unreachable, and the outcome was effectively deletion — the thing `langx2/docs/token-messaging-brief.md` argues is *worse* than leaving the pages up, because a link that dies silently reads as a quiet retraction rather than a correction.

## The fix

The twelve pages are listed again, under a new `## 🗄️ Not Built` group. No page content changes in this PR — only `SUMMARY.md`.

This gets all three properties at once:

- old links resolve, so shared links and search results are not broken
- the notice on each page is actually visible
- the group name states the situation before a reader opens anything, so the section cannot be mistaken for a roadmap

## For the reviewer

The only open question is the group's name. `🗄️ Not Built` is deliberately blunt; `Archive` would be softer but less informative about *why* the pages are there. Easy to change — it is one line.