### PR TITLE
Link the token page from the Welcome quick links

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,6 +4,7 @@
 
 * [🌎 Practice, Learn, Succeed!](README.md)
   * [📲 the "App"](https://get.langx.io)
+  * [🪙 LangX Token](token/token.md)
   * [🎮 Discord](https://discord.langx.io)
   * [🐸 Reddit](https://reddit.com/r/langx)
   * [🐦 X (Twitter)](https://x.com/langx\_io)


### PR DESCRIPTION
Adds `🪙 LangX Token` to the quick links under **🎉 Welcome** in `SUMMARY.md`, between the app link and Discord.

Those links are the first thing in the navigation and currently point only at the app and the community channels. The token is the thing this site is most often opened to read about, so it is worth reaching in one click from the top rather than only from its own section further down.

One line, `SUMMARY.md` only. The page already exists at `token/token.md` and keeps its entry under the **💰 Token** group — GitBook is fine with the same page appearing in two places in the tree.