### PR TITLE
Point the Welcome token link at token.langx.io

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,7 +4,7 @@
 
 * [🌎 Practice, Learn, Succeed!](README.md)
   * [📲 the "App"](https://get.langx.io)
-  * [🪙 LangX Token](token/token.md)
+  * [🪙 LangX Token](https://token.langx.io)
   * [🎮 Discord](https://discord.langx.io)
   * [🐸 Reddit](https://reddit.com/r/langx)
   * [🐦 X (Twitter)](https://x.com/langx\_io)


### PR DESCRIPTION
Changes the `🪙 LangX Token` quick link added in [#14](https://github.com/langx/docs/pull/14) from the in-tree page to **https://token.langx.io**.

The other entries in that group are all external destinations — the app, Discord, Reddit, X — so an internal page link sat oddly among them. token.langx.io is the token's front door, and since [langx/token-website@6d73d55](https://github.com/langx/token-website/commit/6d73d55) it describes the token the same way this litepaper does, so pointing there from the top of the navigation is consistent rather than sending people somewhere that contradicts us.

`token/token.md` keeps its entry under the **💰 Token** group, so nothing becomes unreachable.

One line, `SUMMARY.md` only.