### PR TITLE
Stop advertising the filters as a plain feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  An overview of LangX, a free and open-source language exchange app designed to
+  An overview of LangX, a free-to-use, open-source language exchange app designed to
   connect language learners with native speakers. This document covers the app's
   features, how it works, how to contribute.
 cover: .gitbook/assets/featured_screenshots.jpeg
@@ -63,7 +63,7 @@ We're excited to announce the launch of [LangX](https://get.langx.io), a free-to
 
 We offer a range of features to help you get the most out of your language learning experience:
 
-* **⚙️ Fine Tune Your Connections** : Customize your connection preferences to find the perfect language exchange partners by filtering options.
+* **⚙️ Fine Tune Your Connections** : Browse the community freely, and narrow it down by gender, country, age and level with LangX Pro's filters.
 * **🔍 Profile Insights** : Get insights into your language learning progress and habits directly from your profile.
 * **💬 Just Chat** : Experience our user-friendly chat interface. Learning a language has never been this fun and easy.
 * **🔒 Your Data, Your Privacy** : We respect your privacy. Control what data you share and manage your privacy settings easily.


### PR DESCRIPTION
Two bullets in the same feature list on the front page contradicted each other after [#12](https://github.com/langx/docs/pull/12):

- **⚙️ Fine Tune Your Connections** — offered filtering as part of the feature set
- **💰 Free to Use. Always.** — said filters are one of the things LangX Pro adds

Discovery filters (gender, country, age, CEFR) are **Pro** in v2, per `langx2/docs/legal/promise-change.md`, so the first bullet is the wrong half. It now says what is actually true: browsing the community is free, narrowing it down is Pro.

Also changes the page description from "a free and open-source language exchange app" to "a free-to-use, open-source language exchange app". The app stays free to use and the code stays open — but "free app" stops being precise the moment a subscription exists, and this description is what search engines and link previews quote.

`README.md` only, two lines.